### PR TITLE
Fix capacity tariff

### DIFF
--- a/src/energy_cost/capacity_cost.py
+++ b/src/energy_cost/capacity_cost.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from datetime import UTC
+from typing import Literal
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict
@@ -20,31 +21,39 @@ class CapacityComponent(BaseModel):
 
     def apply(
         self,
-        capacity_data: pd.DataFrame,
+        data: pd.DataFrame,
         timezone: dt.tzinfo = UTC,
+        unit: Literal["MW", "MWh"] = "MWh",
     ) -> pd.DataFrame:
-        # 1. if resolution of capacity data is divisor of measurement_period, resample to measurement_period using sum (else continue, assuming data in higher resolution is already aggregated in a correct way)
-        resolution = detect_resolution(capacity_data["timestamp"])
-        if is_divisor(self.measurement_period, resolution):
-            capacity_data = (
-                capacity_data.set_index("timestamp")
-                .resample(to_pandas_freq(self.measurement_period))
-                .sum()
-                .reset_index()
-            )
-            resolution = self.measurement_period
+        # The data is expected to have a "timestamp" column and a "value" column.
+        # It is expected to be consumption data in MWh at a resolution that is a divisor of the measurment_period
+        # If data is given in MW, it is expected to be the maximum average capacity used in each measurment_period and should be given in a resolution that is a divisor of the billing_period.
 
-        # 2. now, if resolution is divisor of billing period, we can resample to billing period using max (else throw error)
+        resolution = detect_resolution(data["timestamp"])
+
+        if unit == "MWh":
+            # 1. if resolution of capacity data is divisor of measurement_period, resample to measurement_period using sum
+            if is_divisor(self.measurement_period, resolution):
+                data = data.set_index("timestamp").resample(to_pandas_freq(self.measurement_period)).sum().reset_index()
+                resolution = self.measurement_period
+            else:
+                raise ValueError(
+                    f"Data resolution must be a divisor of measurement period {self.measurement_period} for aggregation."
+                )
+            # 2. convert MWh to MW by dividing by the number of hours in the resolution (eg divide by 0.25 for 15min data)
+            hours_in_resolution = resolution.total_seconds() / 3600
+            data["value"] = data["value"] / hours_in_resolution
+            unit = "MW"
+
+        # 3. now, if resolution is divisor of billing period, we can resample to billing period using max (else throw error)
         if not is_divisor(self.billing_period, resolution):
             raise ValueError("Capacity data resolution must be a divisor of billing period for aggregation.")
 
-        capacity_data = (
-            capacity_data.set_index("timestamp").resample(to_pandas_freq(self.billing_period)).max().reset_index()
-        )
+        data = data.set_index("timestamp").resample(to_pandas_freq(self.billing_period)).max().reset_index()
 
-        # 3. apply rolling average if window_periods is set
+        # 4. apply rolling average if window_periods is set
         if self.window_periods is not None:
-            capacity_data["value"] = capacity_data["value"].rolling(window=self.window_periods, min_periods=1).mean()
+            data["value"] = data["value"].rolling(window=self.window_periods, min_periods=1).mean()
 
-        # 4. apply pricing formula to aggregated data
-        return self.formula.apply(capacity_data, resolution=self.billing_period, timezone=timezone)
+        # 5. apply pricing formula to aggregated data
+        return self.formula.apply(data, resolution=self.billing_period, timezone=timezone)

--- a/src/energy_cost/data/be/distributors/fluvius_antwerpen.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_antwerpen.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -48,6 +50,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_halle_vilvoorde.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_halle_vilvoorde.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_imewo.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_imewo.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -48,6 +50,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_kempen.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_kempen.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_limburg.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_limburg.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -48,6 +50,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_midden_vlaanderen.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_midden_vlaanderen.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_west.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_west.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -48,6 +50,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/distributors/fluvius_zenne_dijle.yml
+++ b/src/energy_cost/data/be/distributors/fluvius_zenne_dijle.yml
@@ -4,6 +4,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:
@@ -26,6 +27,7 @@
     billing_period: P1M
     window_periods: 12
     formula:
+      mode: banded
       bands:
       - up_to: 0.0025
         formula:

--- a/src/energy_cost/data/be/parse_distributors.py
+++ b/src/energy_cost/data/be/parse_distributors.py
@@ -156,6 +156,7 @@ def build_entry(year: int, tariffs: dict) -> dict:
             "billing_period": "P1M",
             "window_periods": 12,
             "formula": {
+                "mode": "banded",
                 "bands": [
                     {
                         "up_to": MIN_CAPACITY_MW,
@@ -169,7 +170,7 @@ def build_entry(year: int, tariffs: dict) -> dict:
                             "constant_cost": tariffs["capacity_per_month"],
                         }
                     },
-                ]
+                ],
             },
         },
         "consumption": {

--- a/src/energy_cost/tariff.py
+++ b/src/energy_cost/tariff.py
@@ -3,6 +3,7 @@ import datetime as dt
 from collections.abc import Callable
 from datetime import UTC
 from pathlib import Path
+from typing import Literal
 
 import isodate
 import pandas as pd
@@ -79,6 +80,7 @@ class Tariff(BaseModel):
         start: dt.datetime | None = None,
         end: dt.datetime | None = None,
         timezone: dt.tzinfo = UTC,
+        unit: Literal["MW", "MWh"] = "MWh",
     ) -> pd.DataFrame | None:
         """Apply capacity cost formulas across all active versions.  Returns None when unavailable."""
         detected_start, detected_end, _ = detect_resolution_and_range(data)
@@ -86,7 +88,7 @@ class Tariff(BaseModel):
         end = align_datetime_to_tz(end if end is not None else detected_end, timezone)
         return self._collect_version_frames(
             self._find_active_versions(start, end, timezone),
-            lambda version, seg_start, seg_end: version.apply_capacity_cost(data, timezone),
+            lambda version, seg_start, seg_end: version.apply_capacity_cost(data, timezone, unit=unit),
         )
 
     def apply_energy_cost(

--- a/src/energy_cost/tariff_version.py
+++ b/src/energy_cost/tariff_version.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from collections.abc import Callable
 from datetime import UTC
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import pandas as pd
 from pydantic import BaseModel, BeforeValidator, Field
@@ -117,10 +117,15 @@ class TariffVersion(BaseModel):
             lambda formula: formula.apply(data, timezone=timezone),
         )
 
-    def apply_capacity_cost(self, capacity_data: pd.DataFrame, timezone: dt.tzinfo = UTC) -> pd.DataFrame | None:
+    def apply_capacity_cost(
+        self,
+        capacity_data: pd.DataFrame,
+        timezone: dt.tzinfo = UTC,
+        unit: Literal["MW", "MWh"] = "MWh",
+    ) -> pd.DataFrame | None:
         if self.capacity is None:
             return None
-        return self.capacity.apply(capacity_data, timezone=timezone)
+        return self.capacity.apply(capacity_data, timezone=timezone, unit=unit)
 
     def get_periodic_cost(self, start: dt.datetime, end: dt.datetime, timezone: dt.tzinfo = UTC) -> dict[str, float]:
         return {name: entry.get_cost_for_interval(start, end, timezone) for name, entry in self.periodic.items()}

--- a/tests/test_capacity_cost.py
+++ b/tests/test_capacity_cost.py
@@ -36,7 +36,7 @@ def test_capacity_component_applies_index_formula_to_billing_values() -> None:
         }
     )
 
-    out = component.apply(capacity_data)
+    out = component.apply(capacity_data, unit="MW")
 
     assert out["timestamp"].tolist() == list(pd.to_datetime(["2025-01-01 00:00:00", "2025-02-01 00:00:00"], utc=True))
     assert out["value"].tolist() == [50.0, 70.0]
@@ -61,7 +61,7 @@ def test_capacity_component_applies_banded_tiered_formula() -> None:
         }
     )
 
-    out = component.apply(capacity_data)
+    out = component.apply(capacity_data, unit="MW")
 
     assert out["value"].tolist() == [100.0, 180.0]
 
@@ -93,7 +93,7 @@ def test_capacity_component_supports_scheduled_formulas_inside_bands() -> None:
         }
     )
 
-    out = component.apply(capacity_data)
+    out = component.apply(capacity_data, unit="MW")
 
     assert out["value"].tolist() == [40.0, 16.0]
 
@@ -112,7 +112,7 @@ def test_capacity_component_applies_rolling_average_window() -> None:
         }
     )
 
-    out = component.apply(capacity_data)
+    out = component.apply(capacity_data, unit="MW")
 
     assert out["value"].tolist() == [40.0, 60.0, 90.0]
 
@@ -145,7 +145,7 @@ def test_tariff_applies_capacity_cost_across_version_boundary() -> None:
         }
     )
 
-    out = tariff.apply_capacity_cost(capacity_data)
+    out = tariff.apply_capacity_cost(capacity_data, unit="MW")
 
     assert out is not None
     assert out["timestamp"].tolist() == list(pd.to_datetime(["2025-01-01 00:00:00", "2025-02-01 00:00:00"], utc=True))
@@ -166,3 +166,123 @@ def test_data_frame_resolution_should_be_divisor_of_billing_period() -> None:
     )
 
     pytest.raises(ValueError, component.apply, capacity_data)
+
+
+def test_mw_data_resolution_must_be_divisor_of_billing_period() -> None:
+    """unit=MW data whose resolution is not a divisor of billing_period raises ValueError."""
+    component = CapacityComponent(
+        measurement_period=isodate.parse_duration("P1M"),
+        billing_period=isodate.parse_duration("P1M"),
+        formula=IndexFormula(constant_cost=10.0),
+    )
+    # 2-monthly resolution is not a divisor of 1-month billing period
+    capacity_data = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-01-01 00:00:00", "2025-03-01 00:00:00"]),
+            "value": [5.0, 7.0],
+        }
+    )
+
+    with pytest.raises(ValueError):
+        component.apply(capacity_data, unit="MW")
+
+
+def test_capacity_component_converts_mwh_to_mw_for_15min_data() -> None:
+    """15-min MWh consumption is correctly converted to MW capacity and then billed."""
+    # measurement_period == data resolution == PT15M, billing_period == P1M
+    # Each slot: 2.0 MWh / 0.25h = 8.0 MW; max over January = 8.0 MW; cost = 8.0 * 10.0 = 80.0
+    component = CapacityComponent(
+        measurement_period=isodate.parse_duration("PT15M"),
+        billing_period=isodate.parse_duration("P1M"),
+        formula=IndexFormula(constant_cost=10.0),
+    )
+    timestamps = pd.date_range("2025-01-01 00:00:00", periods=4, freq="15min")
+    capacity_data = pd.DataFrame({"timestamp": timestamps, "value": 2.0})
+
+    out = component.apply(capacity_data)
+
+    assert len(out) == 1
+    assert out["value"].iloc[0] == pytest.approx(80.0)
+
+
+def test_capacity_component_aggregates_15min_mwh_to_hourly_measurement_period() -> None:
+    """15-min MWh data is summed to 1-hour measurement periods before MW conversion."""
+    # 4 slots × 1.0 MWh = 4.0 MWh per hour → 4.0 MWh / 1.0h = 4.0 MW
+    # Two hours in January: max = 4.0 MW; cost = 4.0 * 5.0 = 20.0
+    component = CapacityComponent(
+        measurement_period=isodate.parse_duration("PT1H"),
+        billing_period=isodate.parse_duration("P1M"),
+        formula=IndexFormula(constant_cost=5.0),
+    )
+    timestamps = pd.date_range("2025-01-01 00:00:00", periods=8, freq="15min")
+    capacity_data = pd.DataFrame({"timestamp": timestamps, "value": 1.0})
+
+    out = component.apply(capacity_data)
+
+    assert len(out) == 1
+    assert out["value"].iloc[0] == pytest.approx(20.0)
+
+
+def test_capacity_component_mwh_resolution_must_be_divisor_of_measurement_period() -> None:
+    """MWh data whose resolution is not a divisor of measurement_period raises ValueError."""
+    component = CapacityComponent(
+        measurement_period=isodate.parse_duration("PT1H"),
+        billing_period=isodate.parse_duration("P1M"),
+        formula=IndexFormula(constant_cost=10.0),
+    )
+    # 45-min resolution is not a divisor of 1h
+    timestamps = pd.date_range("2025-01-01 00:00:00", periods=4, freq="45min")
+    capacity_data = pd.DataFrame({"timestamp": timestamps, "value": 1.0})
+
+    with pytest.raises(ValueError):
+        component.apply(capacity_data)
+
+
+def test_tariff_version_apply_capacity_cost_accepts_unit_param() -> None:
+    """TariffVersion.apply_capacity_cost passes the unit param to the capacity component."""
+    version = TariffVersion(
+        start=dt.datetime(2025, 1, 1, 0, 0),
+        capacity=CapacityComponent(
+            measurement_period=isodate.parse_duration("P1M"),
+            billing_period=isodate.parse_duration("P1M"),
+            formula=IndexFormula(constant_cost=10.0),
+        ),
+    )
+    capacity_data = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-01-01 00:00:00", "2025-02-01 00:00:00"]),
+            "value": [3.0, 6.0],
+        }
+    )
+
+    out = version.apply_capacity_cost(capacity_data, unit="MW")
+
+    assert out is not None
+    assert out["value"].tolist() == [30.0, 60.0]
+
+
+def test_tariff_apply_capacity_cost_accepts_unit_param() -> None:
+    """Tariff.apply_capacity_cost passes unit=MW to each version's capacity component."""
+    tariff = Tariff(
+        versions=[
+            TariffVersion(
+                start=dt.datetime(2025, 1, 1, 0, 0),
+                capacity=CapacityComponent(
+                    measurement_period=isodate.parse_duration("P1M"),
+                    billing_period=isodate.parse_duration("P1M"),
+                    formula=IndexFormula(constant_cost=10.0),
+                ),
+            )
+        ]
+    )
+    capacity_data = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2025-01-01 00:00:00", "2025-02-01 00:00:00"]),
+            "value": [4.0, 7.0],
+        }
+    )
+
+    out = tariff.apply_capacity_cost(capacity_data, unit="MW")
+
+    assert out is not None
+    assert out["value"].tolist() == [40.0, 70.0]

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -682,7 +682,7 @@ def test_avoid_regression_on_real_world_data() -> None:
     result = contract.calculate_cost(meters)
     expected = {
         TariffCategory.PROVIDER: 1.22,  # 4 × 0.0025 × (12.0 + 100*1.10) = 1.22 €
-        TariffCategory.DISTRIBUTOR: 12.26457,  # (capacity 0.0025) + (consumption * 50.5027) + (data_management/12) => 10.2924284 + 0.01 * 50.5027 + 17.85/12 = 12.2849 €
+        TariffCategory.DISTRIBUTOR: 43.14186387067,  # (capacity 0.01 * 4116.9713583) + (consumption * 50.5027) + (data_management/12) => 41.1697 + 0.01 * 50.5027 + 17.85/12 = 43.162227 €
         TariffCategory.FEES: 0.475554,  # consumption * (excise + energy_contribution) => 0.475554 €
     }
     expected[TariffCategory.TAXES] = (sum(expected.values())) * tax_rate


### PR DESCRIPTION
This pull request fixes two bugs with capacity tariffs.

1. MWh is now correctly converted to MW
2. Flemish capacity formulas are now correctly treated as Banded instead of Progressive formulas 

Closes #45 