### PR TITLE
Fix missaligment of timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,5 @@ __marimo__/
 
 # ENTSOE index disk cache
 .cache/
+
+local/

--- a/src/energy_cost/contract.py
+++ b/src/energy_cost/contract.py
@@ -91,6 +91,7 @@ class Contract(Versioned):
         start: dt.datetime | None = None,
         end: dt.datetime | None = None,
         resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame:
         """Calculate the full energy bill."""
 
@@ -99,6 +100,7 @@ class Contract(Versioned):
             start = align_datetime_to_tz(start, self.timezone)
         if end is not None:
             end = align_datetime_to_tz(end, self.timezone)
+        binning_anchor = align_datetime_to_tz(binning_anchor, self.timezone) if binning_anchor is not None else start
         if resolution is None:
             resolution = Duration(months=1)
 
@@ -119,6 +121,7 @@ class Contract(Versioned):
                     end=end,
                     resolution=resolution,
                     timezone=self.timezone,
+                    binning_anchor=binning_anchor,
                 )
                 if optional_frame is not None:
                     optional_frame = optional_frame.set_index("timestamp")
@@ -177,7 +180,7 @@ class ContractHistory(VersionedCollection[Contract]):
 
         return self.collect_version_frames(
             lambda contract, seg_start, seg_end: contract.apply(
-                meters, start=seg_start, end=seg_end, resolution=resolution
+                meters, start=seg_start, end=seg_end, resolution=resolution, binning_anchor=start
             ),
             start,
             end,

--- a/src/energy_cost/formula/formula.py
+++ b/src/energy_cost/formula/formula.py
@@ -56,6 +56,7 @@ class Formula(ABC, BaseModel):
         *,
         start: dt.datetime | None = None,
         end: dt.datetime | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame:
         """Apply formula values to a dataframe of quantities and return a single value column."""
         if data.empty:

--- a/src/energy_cost/formula/periodic.py
+++ b/src/energy_cost/formula/periodic.py
@@ -42,6 +42,7 @@ class PeriodicFormula(Formula):
         *,
         start: dt.datetime | None = None,
         end: dt.datetime | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame:
         data = align_timestamps_to_tz(data, timezone)
         if start is None or end is None or resolution is None:
@@ -54,4 +55,4 @@ class PeriodicFormula(Formula):
         period_timestamps = pd.date_range(start=snapped_start, end=end, freq=period_freq, inclusive="left")
 
         coarse_df = pd.DataFrame({"timestamp": period_timestamps, "value": float(self.constant_cost)})
-        return redistribute_to_resolution(coarse_df, self.period, resolution, start, end)
+        return redistribute_to_resolution(coarse_df, self.period, resolution, start, end, binning_anchor=binning_anchor)

--- a/src/energy_cost/formula/periodic.py
+++ b/src/energy_cost/formula/periodic.py
@@ -51,7 +51,7 @@ class PeriodicFormula(Formula):
         period_freq = to_pandas_freq(self.period)
 
         # Snap to period boundary so all periods in [start, end) are covered.
-        snapped_start, _ = snap_billing_period(start, end, period_freq)
+        snapped_start, _ = snap_billing_period(start, end, period_freq, anchor=binning_anchor)
         period_timestamps = pd.date_range(start=snapped_start, end=end, freq=period_freq, inclusive="left")
 
         coarse_df = pd.DataFrame({"timestamp": period_timestamps, "value": float(self.constant_cost)})

--- a/src/energy_cost/formula/tiered.py
+++ b/src/energy_cost/formula/tiered.py
@@ -53,6 +53,7 @@ class TieredFormula(Formula):
         *,
         start: dt.datetime | None = None,
         end: dt.datetime | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame:
         data = align_timestamps_to_tz(data, timezone)
         if start is None or end is None or resolution is None:
@@ -64,7 +65,7 @@ class TieredFormula(Formula):
             period_freq = to_pandas_freq(self.band_period)
             resolution_freq = to_pandas_freq(resolution)
 
-            range_start, range_end = snap_billing_period(start, end, period_freq)
+            range_start, range_end = snap_billing_period(start, end, period_freq, anchor=binning_anchor)
 
             # Build a lookup: period_start → number of resolution slots in a complete period.
             # (Varies per period, e.g. months have different day counts.)
@@ -110,7 +111,12 @@ class TieredFormula(Formula):
                 mask = unmatched if band.up_to is None else unmatched & (period_total <= band.up_to)
                 if mask.any():
                     band_values = band.formula.apply(
-                        input_data.copy(), resolution=resolution, timezone=timezone, start=start, end=end
+                        input_data.copy(),
+                        resolution=resolution,
+                        timezone=timezone,
+                        start=start,
+                        end=end,
+                        binning_anchor=binning_anchor,
                     )
                     result_values = result_values.where(~mask, band_values.set_index("timestamp")["value"])
                 unmatched = unmatched & ~mask
@@ -128,7 +134,12 @@ class TieredFormula(Formula):
                 )
                 if fraction.any():
                     band_values = band.formula.apply(
-                        input_data.copy(), resolution=resolution, timezone=timezone, start=start, end=end
+                        input_data.copy(),
+                        resolution=resolution,
+                        timezone=timezone,
+                        start=start,
+                        end=end,
+                        binning_anchor=binning_anchor,
                     )
                     result_values = result_values + band_values.set_index("timestamp")["value"] * fraction
                 if band.up_to is not None:

--- a/src/energy_cost/resolution.py
+++ b/src/energy_cost/resolution.py
@@ -216,6 +216,7 @@ def redistribute_to_resolution(
     output_resolution: Resolution,
     start: dt.datetime,
     end: dt.datetime,
+    binning_anchor: dt.datetime | None = None,
 ) -> pd.DataFrame:
     """Convert *df* from *source_resolution* to *output_resolution*."""
 
@@ -229,9 +230,27 @@ def redistribute_to_resolution(
         result = _distribute(result, source_resolution, gcd, start, end)
 
     if gcd != output_resolution:
-        result = result.set_index("timestamp").resample(to_pandas_freq(output_resolution)).sum().reset_index()
+        anchor = binning_anchor if binning_anchor is not None else start
+        result = _aggregate_to_resolution(result, output_resolution, anchor, end)
 
     return result
+
+
+def _aggregate_to_resolution(
+    df: pd.DataFrame,
+    output_resolution: Resolution,
+    start: dt.datetime,
+    end: dt.datetime,
+) -> pd.DataFrame:
+    """Aggregate *df* into *output_resolution* bins anchored to *start*."""
+    freq = to_pandas_freq(output_resolution)
+    snapped_start, snapped_end = snap_billing_period(start, end, freq)
+    bin_df = pd.DataFrame({"__bin": pd.date_range(start=snapped_start, end=snapped_end, freq=freq, inclusive="left")})
+    merged = pd.merge_asof(df, bin_df, left_on="timestamp", right_on="__bin", direction="backward")
+    value_cols = [c for c in merged.columns if c not in ("timestamp", "__bin")]
+    return (
+        merged.groupby("__bin")[value_cols].sum(numeric_only=True).reset_index().rename(columns={"__bin": "timestamp"})
+    )
 
 
 def detect_resolution_and_range(

--- a/src/energy_cost/resolution.py
+++ b/src/energy_cost/resolution.py
@@ -122,30 +122,55 @@ def snap_billing_period(
     billing_start: dt.datetime,
     billing_end: dt.datetime,
     output_freq: str,
+    anchor: dt.datetime | None = None,
 ) -> tuple[dt.datetime, dt.datetime]:
-    """Snap billing start/end to clean output-period boundaries (floor start, ceil end).
+    """Snap billing start/end outward to output-period boundaries derived from *anchor*.
 
-    For example, with monthly output and data starting on 2026-04-09, billing_start
-    is snapped back to 2026-04-01 and billing_end forward to the next month start.
+    The snap points form the series ``anchor_norm + x * offset`` where *anchor_norm* is
+    *anchor* normalised to midnight (and for calendar offsets rolled back to the 1st of
+    the month/year).  When *anchor* is ``None`` it defaults to *billing_start*.
+
+    Returns ``(latest snap <= billing_start, earliest snap >= billing_end)``.
     """
+    if anchor is None:
+        anchor = billing_start
+
     offset = pd.tseries.frequencies.to_offset(output_freq)
     assert offset is not None
 
-    if not isinstance(offset, pd.tseries.offsets.Tick):
-        # Calendar offsets (MonthBegin, YearBegin, …) consider any day-1 timestamp
-        # "on-offset" regardless of time-of-day, so rollforward/rollback preserve
-        # non-midnight times. Normalize to midnight first (pd.Timestamp.normalize()
-        # handles DST-aware timezones correctly), then handle the ceiling case: if
-        # the original ts_end was after midnight on a day that rollforward considers
-        # already on-offset, advance one extra period.
+    ts_anchor = cast(pd.Timestamp, pd.Timestamp(anchor))
+
+    try:
+        tick_nanos = offset.nanos
+    except ValueError:
+        tick_nanos = None
+
+    if tick_nanos is None:
+        # Calendar offsets (MonthBegin, YearBegin, …): the anchor is normalised to
+        # midnight on the 1st of the month/year so the grid is always the natural
+        # calendar boundary.  Different anchors therefore always produce the same grid.
         snapped_start = cast(pd.Timestamp, pd.Timestamp(offset.rollback(billing_start))).normalize()
+
         end_norm = cast(pd.Timestamp, pd.Timestamp(billing_end)).normalize()
         snapped_end = offset.rollforward(end_norm)
         if end_norm < billing_end and snapped_end == end_norm:
             snapped_end = snapped_end + offset
     else:
-        snapped_start = offset.rollback(billing_start)
-        snapped_end = offset.rollforward(billing_end)
+        # Fixed-duration offsets (Day, Hour, Minute, …): normalise anchor to midnight
+        # and compute snap points as anchor_norm + n * offset.
+        anchor_norm = ts_anchor.normalize()
+        ts_start = cast(pd.Timestamp, pd.Timestamp(billing_start))
+        ts_end = cast(pd.Timestamp, pd.Timestamp(billing_end))
+
+        # Latest snap point <= billing_start  (floor division from anchor_norm)
+        delta_start = (ts_start - anchor_norm).value
+        n_start = delta_start // tick_nanos if delta_start >= 0 else -((-delta_start - 1) // tick_nanos + 1)
+        snapped_start = anchor_norm + n_start * offset
+
+        # Earliest snap point >= billing_end  (ceiling division from anchor_norm)
+        delta_end = (ts_end - anchor_norm).value
+        n_end = -(-delta_end // tick_nanos)  # ceiling division
+        snapped_end = anchor_norm + n_end * offset
 
     return snapped_start, snapped_end
 
@@ -181,13 +206,14 @@ def _distribute(
     output_resolution: Resolution,
     start: dt.datetime,
     end: dt.datetime,
+    binning_anchor: dt.datetime | None = None,
 ) -> pd.DataFrame:
     """Distribute coarse *source_resolution* values proportionally into finer *output_resolution* bins."""
     source_freq = to_pandas_freq(source_resolution)
     output_freq = to_pandas_freq(output_resolution)
 
     # Snap to full source periods so every coarse slot is fully populated in the target index.
-    snapped_start, snapped_end = snap_billing_period(start, end, source_freq)
+    snapped_start, snapped_end = snap_billing_period(start, end, source_freq, anchor=binning_anchor)
 
     target_df = pd.DataFrame(
         {
@@ -227,11 +253,10 @@ def redistribute_to_resolution(
     result = df
 
     if gcd != source_resolution:
-        result = _distribute(result, source_resolution, gcd, start, end)
+        result = _distribute(result, source_resolution, gcd, start, end, binning_anchor=binning_anchor)
 
     if gcd != output_resolution:
-        anchor = binning_anchor if binning_anchor is not None else start
-        result = _aggregate_to_resolution(result, output_resolution, anchor, end)
+        result = _aggregate_to_resolution(result, output_resolution, start, end, binning_anchor=binning_anchor)
 
     return result
 
@@ -241,10 +266,11 @@ def _aggregate_to_resolution(
     output_resolution: Resolution,
     start: dt.datetime,
     end: dt.datetime,
+    binning_anchor: dt.datetime | None = None,
 ) -> pd.DataFrame:
     """Aggregate *df* into *output_resolution* bins anchored to *start*."""
     freq = to_pandas_freq(output_resolution)
-    snapped_start, snapped_end = snap_billing_period(start, end, freq)
+    snapped_start, snapped_end = snap_billing_period(start, end, freq, anchor=binning_anchor)
     bin_df = pd.DataFrame({"__bin": pd.date_range(start=snapped_start, end=snapped_end, freq=freq, inclusive="left")})
     merged = pd.merge_asof(df, bin_df, left_on="timestamp", right_on="__bin", direction="backward")
     value_cols = [c for c in merged.columns if c not in ("timestamp", "__bin")]

--- a/src/energy_cost/tariff.py
+++ b/src/energy_cost/tariff.py
@@ -147,6 +147,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         timezone: dt.tzinfo = UTC,
         include_meter_type: bool = False,
         tariff_category: TariffCategory | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         if resolution is None:
             resolution = isodate.Duration(months=1)
@@ -161,13 +162,16 @@ class Tariff(VersionedCollection[TariffVersion]):
             start = align_datetime_to_tz(start, timezone)
         if end is not None:
             end = align_datetime_to_tz(end, timezone)
+        if binning_anchor is not None:
+            binning_anchor = align_datetime_to_tz(binning_anchor, timezone)
 
         detected_start, detected_end, data_resolution = detect_resolution_and_range(combined_consumption)
         billing_start: dt.datetime = start if start is not None else detected_start
         billing_end: dt.datetime = end if end is not None else detected_end
         output_freq = to_pandas_freq(resolution)
 
-        billing_start, billing_end = snap_billing_period(billing_start, billing_end, output_freq)
+        billing_start, billing_end = snap_billing_period(billing_start, billing_end, output_freq, anchor=binning_anchor)
+        downstream_anchor = binning_anchor if binning_anchor is not None else billing_start
 
         frames: list[pd.DataFrame] = []
         for meter in meters:
@@ -181,13 +185,16 @@ class Tariff(VersionedCollection[TariffVersion]):
                 resolution,
                 timezone,
                 input_resolution=data_resolution,
+                binning_anchor=downstream_anchor,
             )
             if frame is not None:
                 frames.append(frame)
 
         for optional_frame in [
-            self._apply_capacity_costs(combined_consumption, billing_start, billing_end, resolution, timezone),
-            self._apply_fixed_costs(billing_start, billing_end, resolution, timezone),
+            self._apply_capacity_costs(
+                combined_consumption, billing_start, billing_end, resolution, timezone, binning_anchor=downstream_anchor
+            ),
+            self._apply_fixed_costs(billing_start, billing_end, resolution, timezone, binning_anchor=downstream_anchor),
         ]:
             if optional_frame is not None:
                 frames.append(optional_frame)
@@ -222,6 +229,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         resolution: Resolution,
         timezone: dt.tzinfo = UTC,
         input_resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         costs = self.apply_energy_cost(
             data,
@@ -232,7 +240,7 @@ class Tariff(VersionedCollection[TariffVersion]):
             timezone,
             output_resolution=resolution,
             input_resolution=input_resolution,
-            binning_anchor=billing_start,
+            binning_anchor=billing_start if binning_anchor is None else binning_anchor,
         )
         if costs is None:
             return None
@@ -251,6 +259,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         billing_end: dt.datetime,
         resolution: Resolution,
         timezone: dt.tzinfo = UTC,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         capacity_df = self.apply_capacity_cost(
             consumption,
@@ -258,7 +267,7 @@ class Tariff(VersionedCollection[TariffVersion]):
             billing_end,
             timezone,
             output_resolution=resolution,
-            binning_anchor=billing_start,
+            binning_anchor=billing_start if binning_anchor is None else binning_anchor,
         )
         if capacity_df is None or capacity_df.empty:
             return None
@@ -272,9 +281,14 @@ class Tariff(VersionedCollection[TariffVersion]):
         billing_end: dt.datetime,
         resolution: Resolution,
         timezone: dt.tzinfo = UTC,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         fixed_df = self.apply_periodic_costs(
-            billing_start, billing_end, output_resolution=resolution, timezone=timezone, binning_anchor=billing_start
+            billing_start,
+            billing_end,
+            output_resolution=resolution,
+            timezone=timezone,
+            binning_anchor=billing_start if binning_anchor is None else binning_anchor,
         )
         if fixed_df is None or fixed_df.empty:
             return None

--- a/src/energy_cost/tariff.py
+++ b/src/energy_cost/tariff.py
@@ -49,6 +49,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         timezone: dt.tzinfo = UTC,
         unit: Literal["MW", "MWh"] = "MWh",
         output_resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply capacity cost formulas across all active versions.  Returns None when unavailable."""
         if start is None or end is None:
@@ -59,6 +60,7 @@ class Tariff(VersionedCollection[TariffVersion]):
                 end = detected_end
         start = align_datetime_to_tz(start, timezone)
         end = align_datetime_to_tz(end, timezone)
+        _binning_anchor = binning_anchor if binning_anchor is not None else start
         return self.collect_version_frames(
             lambda version, seg_start, seg_end: version.apply_capacity_cost(
                 data,
@@ -67,6 +69,7 @@ class Tariff(VersionedCollection[TariffVersion]):
                 timezone=timezone,
                 unit=unit,
                 output_resolution=output_resolution,
+                binning_anchor=_binning_anchor,
             ),
             start,
             end,
@@ -83,6 +86,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         timezone: dt.tzinfo = UTC,
         output_resolution: Resolution | None = None,
         input_resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply energy cost formulas to quantity data across all active versions."""
         if start is None or end is None or input_resolution is None:
@@ -95,6 +99,7 @@ class Tariff(VersionedCollection[TariffVersion]):
                 input_resolution = detected_resolution
         start = align_datetime_to_tz(start, timezone)
         end = align_datetime_to_tz(end, timezone)
+        _binning_anchor = binning_anchor if binning_anchor is not None else start
         return self.collect_version_frames(
             lambda version, seg_start, seg_end: version.apply_energy_cost(
                 data,
@@ -105,6 +110,7 @@ class Tariff(VersionedCollection[TariffVersion]):
                 end=seg_end,
                 input_resolution=input_resolution,
                 output_resolution=output_resolution,
+                binning_anchor=_binning_anchor,
             ),
             start,
             end,
@@ -117,13 +123,15 @@ class Tariff(VersionedCollection[TariffVersion]):
         end: dt.datetime,
         output_resolution: Resolution,
         timezone: dt.tzinfo = UTC,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply periodic cost formulas across all active versions, returning a DataFrame with a column per named cost."""
         start = align_datetime_to_tz(start, timezone)
         end = align_datetime_to_tz(end, timezone)
+        _binning_anchor = binning_anchor if binning_anchor is not None else start
         return self.collect_version_frames(
             lambda version, seg_start, seg_end: version.apply_periodic_costs(
-                seg_start, seg_end, output_resolution, timezone
+                seg_start, seg_end, output_resolution, timezone, binning_anchor=_binning_anchor
             ),
             start,
             end,
@@ -224,6 +232,7 @@ class Tariff(VersionedCollection[TariffVersion]):
             timezone,
             output_resolution=resolution,
             input_resolution=input_resolution,
+            binning_anchor=billing_start,
         )
         if costs is None:
             return None
@@ -249,6 +258,7 @@ class Tariff(VersionedCollection[TariffVersion]):
             billing_end,
             timezone,
             output_resolution=resolution,
+            binning_anchor=billing_start,
         )
         if capacity_df is None or capacity_df.empty:
             return None
@@ -264,7 +274,7 @@ class Tariff(VersionedCollection[TariffVersion]):
         timezone: dt.tzinfo = UTC,
     ) -> pd.DataFrame | None:
         fixed_df = self.apply_periodic_costs(
-            billing_start, billing_end, output_resolution=resolution, timezone=timezone
+            billing_start, billing_end, output_resolution=resolution, timezone=timezone, binning_anchor=billing_start
         )
         if fixed_df is None or fixed_df.empty:
             return None

--- a/src/energy_cost/tariff_version.py
+++ b/src/energy_cost/tariff_version.py
@@ -126,7 +126,14 @@ class TariffVersion(Versioned):
         result = self._combine_energy_formulas(
             meter_type,
             direction,
-            lambda formula: formula.apply(data, timezone=timezone, resolution=input_resolution, start=start, end=end),
+            lambda formula: formula.apply(
+                data,
+                timezone=timezone,
+                resolution=input_resolution,
+                start=start,
+                end=end,
+                binning_anchor=binning_anchor,
+            ),
         )
 
         if output_resolution is not None and result is not None:

--- a/src/energy_cost/tariff_version.py
+++ b/src/energy_cost/tariff_version.py
@@ -116,6 +116,7 @@ class TariffVersion(Versioned):
         input_resolution: Resolution,
         timezone: dt.tzinfo = UTC,
         output_resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply energy cost formulas to quantity data in [start, end), returning costs in €."""
         data = data[(data["timestamp"] >= start) & (data["timestamp"] < end)].copy()
@@ -129,7 +130,9 @@ class TariffVersion(Versioned):
         )
 
         if output_resolution is not None and result is not None:
-            result = redistribute_to_resolution(result, input_resolution, output_resolution, start, end)
+            result = redistribute_to_resolution(
+                result, input_resolution, output_resolution, start, end, binning_anchor=binning_anchor
+            )
         return result
 
     def apply_capacity_cost(
@@ -140,6 +143,7 @@ class TariffVersion(Versioned):
         timezone: dt.tzinfo = UTC,
         unit: Literal["MW", "MWh"] = "MWh",
         output_resolution: Resolution | None = None,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply capacity cost formula in [start, end), returning costs in €."""
         if self.capacity is None:
@@ -149,7 +153,9 @@ class TariffVersion(Versioned):
         result = result[(result["timestamp"] >= start) & (result["timestamp"] < end)].copy()
 
         if output_resolution is not None and not result.empty:
-            result = redistribute_to_resolution(result, self.capacity.billing_period, output_resolution, start, end)
+            result = redistribute_to_resolution(
+                result, self.capacity.billing_period, output_resolution, start, end, binning_anchor=binning_anchor
+            )
         return result
 
     def apply_periodic_costs(
@@ -158,19 +164,30 @@ class TariffVersion(Versioned):
         end: dt.datetime,
         output_resolution: Resolution,
         timezone: dt.tzinfo = UTC,
+        binning_anchor: dt.datetime | None = None,
     ) -> pd.DataFrame | None:
         """Apply periodic cost formulas in [start, end), returning a DataFrame with a column per named cost."""
         if not self.periodic:
             return None
 
-        output_ts = pd.date_range(start=start, end=end, freq=to_pandas_freq(output_resolution), inclusive="left")
+        sentinel_start = binning_anchor if binning_anchor is not None else start
+        output_ts = pd.date_range(
+            start=sentinel_start, end=end, freq=to_pandas_freq(output_resolution), inclusive="left"
+        )
         if output_ts.empty:
             return None
         sentinel = pd.DataFrame({"timestamp": output_ts})
 
         result: pd.DataFrame | None = None
         for name, formula in self.periodic.items():
-            df = formula.apply(sentinel, resolution=output_resolution, timezone=timezone, start=start, end=end)
+            df = formula.apply(
+                sentinel,
+                resolution=output_resolution,
+                timezone=timezone,
+                start=start,
+                end=end,
+                binning_anchor=binning_anchor,
+            )
             df = df.rename(columns={"value": name})
             result = df if result is None else result.merge(df, on="timestamp", how="outer")
         return result

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1326,3 +1326,63 @@ def test_contract_history_from_yaml(tmp_path) -> None:
     assert len(history.versions) == 2
     assert history.versions[0].end == dt.datetime(2025, 6, 1, tzinfo=dt.UTC)
     assert history.versions[1].end is None
+
+
+# ---------------------------------------------------------------------------
+# Regression — weekly binning anchor misalignment (fees vs. supplier)
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_output_no_nan_when_fees_and_supplier_span_different_version_segments() -> None:
+    """Regression: weekly (P7D) output must not produce NaN rows when a supplier tariff
+    has a version boundary mid-billing-window while the fees tariff is a single version
+    spanning the whole window.
+
+    Without the ``binning_anchor`` fix, each tariff component used its own segment
+    start as the resample anchor.  The supplier's January-2026 segment started on
+    2026-01-01 (Thursday), anchoring its weekly bins to Thursdays (Jan 1, Jan 8, …).
+    The fees component had a single version whose segment start equalled billing_start
+    (June 1, 2025 — a Sunday), anchoring its bins to Sundays (Jan 4, Jan 11, …).
+    The two DataFrames were then merged via ``pd.concat(axis=1)``, producing
+    alternating rows of NaN where timestamps didn't match.
+    """
+    # Supplier: version boundary at 2026-01-01 (Thursday in UTC), which is offset from
+    # billing_start so the two produce weekly bins on different days of week.
+    supplier = Tariff(
+        versions=[
+            TariffVersion(
+                start=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                consumption={"all": {"energy": IndexFormula(constant_cost=10.0)}},
+            ),
+            TariffVersion(
+                start=dt.datetime(2026, 1, 1, tzinfo=dt.UTC),
+                consumption={"all": {"energy": IndexFormula(constant_cost=20.0)}},
+            ),
+        ]
+    )
+    # Fees: single version (started long before billing window) with only a periodic
+    # monthly fixed cost, which must go through redistribute_to_resolution (P1M → P7D).
+    fees = Tariff(
+        versions=[
+            TariffVersion(
+                start=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+                periodic={"fund": PeriodicFormula(period=isodate.parse_duration("P1M"), constant_cost=5.0)},
+            )
+        ]
+    )
+    contract = Contract(supplier=supplier, fees=fees, timezone=dt.UTC)
+
+    billing_start = dt.datetime(2025, 6, 1, tzinfo=dt.UTC)
+    # Daily data spanning the version boundary; enough to fill every weekly bin.
+    timestamps = pd.date_range(billing_start, dt.datetime(2026, 1, 15, tzinfo=dt.UTC), freq="D", inclusive="left")
+    consumption = pd.DataFrame({"timestamp": timestamps, "value": 1.0})
+
+    result = contract.apply([Meter(data=consumption)], start=billing_start, resolution=isodate.parse_duration("P7D"))
+
+    assert result is not None
+    data_cols = [c for c in result.columns if c != "timestamp"]
+    nan_rows = result[result[data_cols].isnull().any(axis=1)]
+    assert len(nan_rows) == 0, (
+        f"Found {len(nan_rows)} NaN row(s) — weekly bins misaligned between tariff components:\n"
+        f"{nan_rows[['timestamp']].to_string()}"
+    )

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,5 +1,6 @@
 import datetime
 import datetime as dt
+from typing import cast
 
 import isodate
 import pandas as pd
@@ -13,6 +14,7 @@ from energy_cost.resolution import (
     is_divisor,
     parse_resolution,
     redistribute_to_resolution,
+    snap_billing_period,
     to_pandas_freq,
 )
 
@@ -402,3 +404,80 @@ def test_redistribute_to_resolution_case_c_month_to_week_via_day() -> None:
     # Jan 1–7 (7 days), Jan 8–14 (7), Jan 15–21 (7), Jan 22–28 (7), Jan 29–31 (3)
     expected = [310.0 * n / 31 for n in (7, 7, 7, 7, 3)]
     assert result["value"].tolist() == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# snap_billing_period: anchor-based snapping
+# ---------------------------------------------------------------------------
+
+
+def test_snap_billing_period_7d_default_anchor_uses_billing_start() -> None:
+    """Without explicit anchor, snap points derive from billing_start (normalised to midnight)."""
+    billing_start = dt.datetime(2026, 2, 1, tzinfo=dt.UTC)  # Sunday
+    billing_end = dt.datetime(2026, 2, 22, tzinfo=dt.UTC)
+    snapped_start, snapped_end = snap_billing_period(billing_start, billing_end, "7D")
+    assert snapped_start == pd.Timestamp(billing_start)
+    assert snapped_end >= pd.Timestamp(billing_end)
+    delta = pd.Timedelta(snapped_end - pd.Timestamp(billing_start))
+    assert delta.value % pd.Timedelta("7D").value == 0
+
+
+def test_snap_billing_period_7d_explicit_anchor() -> None:
+    """With an explicit anchor, snap points are anchor_midnight + x*7D."""
+    anchor = dt.datetime(2026, 1, 5, tzinfo=dt.UTC)  # Monday
+    billing_start = dt.datetime(2026, 2, 1, tzinfo=dt.UTC)  # Sunday
+    billing_end = dt.datetime(2026, 2, 22, tzinfo=dt.UTC)
+    snapped_start, snapped_end = snap_billing_period(billing_start, billing_end, "7D", anchor=anchor)
+    anchor_norm = cast(pd.Timestamp, pd.Timestamp(anchor)).normalize()
+    # snapped_start must be <= billing_start and on the anchor grid
+    assert snapped_start <= pd.Timestamp(billing_start)
+    assert pd.Timedelta(snapped_start - anchor_norm).value % pd.Timedelta("7D").value == 0
+    # snapped_end must be >= billing_end and on the anchor grid
+    assert snapped_end >= pd.Timestamp(billing_end)
+    assert pd.Timedelta(snapped_end - anchor_norm).value % pd.Timedelta("7D").value == 0
+
+
+def test_snap_billing_period_7d_no_shift_when_billing_start_is_on_anchor_grid() -> None:
+    """When billing_start falls exactly on the anchor grid, snapped_start == billing_start."""
+    billing_start = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)  # Thursday
+    billing_end = dt.datetime(2026, 1, 29, tzinfo=dt.UTC)
+    snapped_start, snapped_end = snap_billing_period(billing_start, billing_end, "7D")
+    assert snapped_start == pd.Timestamp(billing_start)
+    assert snapped_end >= pd.Timestamp(billing_end)
+
+
+def test_snap_billing_period_consistent_across_different_starts_with_same_anchor() -> None:
+    """Two different billing windows with the same anchor must produce snap points on the same grid."""
+    anchor = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
+    s1, e1 = snap_billing_period(
+        dt.datetime(2026, 1, 5, tzinfo=dt.UTC),
+        dt.datetime(2026, 1, 20, tzinfo=dt.UTC),
+        "7D",
+        anchor=anchor,
+    )
+    s2, e2 = snap_billing_period(
+        dt.datetime(2026, 2, 3, tzinfo=dt.UTC),
+        dt.datetime(2026, 2, 18, tzinfo=dt.UTC),
+        "7D",
+        anchor=anchor,
+    )
+    anchor_norm = cast(pd.Timestamp, pd.Timestamp(anchor)).normalize()
+    # Both snapped_starts must be on the same grid
+    assert pd.Timedelta(s1 - anchor_norm).value % pd.Timedelta("7D").value == 0
+    assert pd.Timedelta(s2 - anchor_norm).value % pd.Timedelta("7D").value == 0
+
+
+def test_redistribute_to_resolution_7d_bins_start_at_billing_start_not_epoch_thursday() -> None:
+    """Aggregating hourly data to P7D must produce bins aligned to billing_start, not
+    to the Unix epoch's Thursday, even when billing_start falls on another weekday."""
+    billing_start = dt.datetime(2026, 2, 2, tzinfo=dt.UTC)
+    billing_end = dt.datetime(2026, 2, 16, tzinfo=dt.UTC)
+    timestamps = pd.date_range(billing_start, billing_end, freq="1h", inclusive="left")
+    df = pd.DataFrame({"timestamp": timestamps, "value": [1.0] * len(timestamps)})
+
+    result = redistribute_to_resolution(df, dt.timedelta(hours=1), dt.timedelta(weeks=1), billing_start, billing_end)
+
+    assert len(result) == 2
+    assert result["timestamp"].iloc[0] == pd.Timestamp(billing_start)
+    assert result["timestamp"].iloc[1] == pd.Timestamp(billing_start) + pd.Timedelta("7D")
+    assert result["value"].sum() == pytest.approx(14 * 24)


### PR DESCRIPTION
This pull request fixes a bug where fees and supplier costs where misaligned, with each appearing on different timestamps, when asked in weekly resolution

The underlying bug was more fundamental.
Each part of a contract generates their own response timeseries, in the requested resolution. For cases like a monthly resolution, it is well defined that these all start at the first of the month.

But for resolutions like `P7D` or `P3D`, this is not well defined.
I have now defined an anchor as midnight on the first requested day. From this each timestamp will be `anchor + x * resolution`.

I pass through this `binning_anchor`  in every method, such that everything that generates a timestamp series can do so correctly.