### PR TITLE
Remove postponed Belgian gas excise

### DIFF
--- a/src/energy_cost/data/be/gas/fees/residential.yml
+++ b/src/energy_cost/data/be/gas/fees/residential.yml
@@ -160,15 +160,3 @@
             constant_cost: 8.23
         - formula:
             constant_cost: 9.0782
-- start: "2026-04-01T00:00:00+02:00"
-  consumption:
-    energy_contribution:
-      constant_cost: 0.9978
-    excise:
-      band_period: P1Y
-      bands:
-        - up_to: 12
-          formula:
-            constant_cost: 8.23
-        - formula:
-            constant_cost: 9.3061


### PR DESCRIPTION
This pull request removes the excise increase of 2026-04-01 as the law about that excise change has been postponed: https://www.vrt.be/vrtnws/nl/2026/03/25/uitstel-stemming-programmawet-gevolgen/

The excise w=is still listed in the data source: https://www.minfin.fgov.be/myminfin-web/pages/public/fisconet/document/b91925cd-fbba-4da5-8b9a-06974300ff1e#_Toc2592361
But marked in red (without any comments). Something to look out for in the future.