### PR TITLE
Allow optionally forward filling index values

### DIFF
--- a/src/energy_cost/index/cached_entsoe_day_ahead_index.py
+++ b/src/energy_cost/index/cached_entsoe_day_ahead_index.py
@@ -47,17 +47,14 @@ class CachedEntsoeDayAheadIndex(Index):
         cache_dir: Path | str | None = None,
         old_threshold: dt.timedelta = _OLD_DATA_THRESHOLD,
         refresh_interval: dt.timedelta = _REFRESH_INTERVAL,
-        forward_fill: bool = False,
     ) -> None:
-        self._source = EntsoeDayAheadIndex(
-            country_code=country_code, api_key=api_key, resolution=resolution, forward_fill=forward_fill
-        )
+        self._source = EntsoeDayAheadIndex(country_code=country_code, api_key=api_key, resolution=resolution)
         self.country_code = country_code
         self.cache_dir = Path(cache_dir) if cache_dir is not None else _DEFAULT_CACHE_DIR
         self.old_threshold = old_threshold
         self.refresh_interval = refresh_interval
         self._mem_cache: pd.DataFrame | None = None
-        super().__init__(resolution=resolution, forward_fill=forward_fill)
+        super().__init__(resolution=resolution)
 
     def _cache_path(self) -> Path:
         self.cache_dir.mkdir(parents=True, exist_ok=True)

--- a/src/energy_cost/index/cached_entsoe_day_ahead_index.py
+++ b/src/energy_cost/index/cached_entsoe_day_ahead_index.py
@@ -47,14 +47,17 @@ class CachedEntsoeDayAheadIndex(Index):
         cache_dir: Path | str | None = None,
         old_threshold: dt.timedelta = _OLD_DATA_THRESHOLD,
         refresh_interval: dt.timedelta = _REFRESH_INTERVAL,
+        forward_fill: bool = False,
     ) -> None:
-        self._source = EntsoeDayAheadIndex(country_code=country_code, api_key=api_key, resolution=resolution)
+        self._source = EntsoeDayAheadIndex(
+            country_code=country_code, api_key=api_key, resolution=resolution, forward_fill=forward_fill
+        )
         self.country_code = country_code
         self.cache_dir = Path(cache_dir) if cache_dir is not None else _DEFAULT_CACHE_DIR
         self.old_threshold = old_threshold
         self.refresh_interval = refresh_interval
         self._mem_cache: pd.DataFrame | None = None
-        super().__init__(resolution=resolution)
+        super().__init__(resolution=resolution, forward_fill=forward_fill)
 
     def _cache_path(self) -> Path:
         self.cache_dir.mkdir(parents=True, exist_ok=True)

--- a/src/energy_cost/index/dataframe_index.py
+++ b/src/energy_cost/index/dataframe_index.py
@@ -8,7 +8,7 @@ from .index import Index
 
 
 class DataFrameIndex(Index):
-    def __init__(self, df: pd.DataFrame, resolution: Resolution | None = None):
+    def __init__(self, df: pd.DataFrame, resolution: Resolution | None = None, forward_fill: bool = False):
         if "timestamp" not in df.columns or "value" not in df.columns:
             raise ValueError("DataFrame must contain 'timestamp' and 'value' columns.")
         df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
@@ -17,7 +17,7 @@ class DataFrameIndex(Index):
         if resolution is None:
             resolution = detect_resolution(self.df["timestamp"])
 
-        super().__init__(resolution=resolution)
+        super().__init__(resolution=resolution, forward_fill=forward_fill)
 
     def _get_values(self, start: pd.Timestamp, end: pd.Timestamp, timezone: dt.tzinfo) -> pd.DataFrame:
         df = self.df.copy()  # work on a copy to avoid mutating self.df
@@ -26,16 +26,16 @@ class DataFrameIndex(Index):
 
 
 class CSVIndex(DataFrameIndex):
-    def __init__(self, csv_path: str, resolution: Resolution | None = None):
+    def __init__(self, csv_path: str, resolution: Resolution | None = None, forward_fill: bool = False):
         df = pd.read_csv(csv_path, parse_dates=["timestamp"])
-        super().__init__(df, resolution=resolution)
+        super().__init__(df, resolution=resolution, forward_fill=forward_fill)
 
 
 class YAMLIndex(DataFrameIndex):
-    def __init__(self, yaml_path: str, resolution: Resolution | None = None):
+    def __init__(self, yaml_path: str, resolution: Resolution | None = None, forward_fill: bool = False):
         import yaml
 
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
         df = pd.DataFrame(data)
-        super().__init__(df, resolution=resolution)
+        super().__init__(df, resolution=resolution, forward_fill=forward_fill)

--- a/src/energy_cost/index/entsoe_day_ahead_index.py
+++ b/src/energy_cost/index/entsoe_day_ahead_index.py
@@ -11,10 +11,16 @@ from .index import Index
 class EntsoeDayAheadIndex(Index):
     """An ENTSO-E day-ahead index for a given country."""
 
-    def __init__(self, country_code: str, api_key: str, resolution: dt.timedelta = dt.timedelta(minutes=15)) -> None:
+    def __init__(
+        self,
+        country_code: str,
+        api_key: str,
+        resolution: dt.timedelta = dt.timedelta(minutes=15),
+        forward_fill: bool = False,
+    ) -> None:
         self.client = EntsoePandasClient(api_key=api_key)
         self.country_code = country_code
-        super().__init__(resolution=resolution)
+        super().__init__(resolution=resolution, forward_fill=forward_fill)
 
     def _get_values(self, start: pd.Timestamp, end: pd.Timestamp, timezone: dt.tzinfo) -> pd.DataFrame:
         """Get the index values for the given time range in €/MWh."""

--- a/src/energy_cost/index/entsoe_day_ahead_index.py
+++ b/src/energy_cost/index/entsoe_day_ahead_index.py
@@ -16,11 +16,10 @@ class EntsoeDayAheadIndex(Index):
         country_code: str,
         api_key: str,
         resolution: dt.timedelta = dt.timedelta(minutes=15),
-        forward_fill: bool = False,
     ) -> None:
         self.client = EntsoePandasClient(api_key=api_key)
         self.country_code = country_code
-        super().__init__(resolution=resolution, forward_fill=forward_fill)
+        super().__init__(resolution=resolution)
 
     def _get_values(self, start: pd.Timestamp, end: pd.Timestamp, timezone: dt.tzinfo) -> pd.DataFrame:
         """Get the index values for the given time range in €/MWh."""

--- a/src/energy_cost/index/index.py
+++ b/src/energy_cost/index/index.py
@@ -18,8 +18,9 @@ from ..resolution import (
 class Index(RegistryMixin[str, "Index"], ABC):
     """An index used for calculating energy costs (€/MWh)."""
 
-    def __init__(self, resolution: Resolution) -> None:
+    def __init__(self, resolution: Resolution, forward_fill: bool = False) -> None:
         self.resolution = resolution
+        self.forward_fill = forward_fill
 
     def get_values(
         self,
@@ -47,9 +48,9 @@ class Index(RegistryMixin[str, "Index"], ABC):
         fetch_start = start_ts - native_resolution_offset
         raw = self._get_values(fetch_start, end_ts, timezone)
 
-        # explicitly add a timestamp one native resolution after the last raw timestamp with value `nan`
-        # This way, they are not forward-filled with the last known value, but correctly marked as out-of-range.
-        if not raw.empty:
+        if not raw.empty and not self.forward_fill:
+            # explicitly add a timestamp one native resolution after the last raw timestamp with value `nan`
+            # This way, they are not forward-filled with the last known value, but correctly marked as out-of-range.
             last_raw_ts = raw["timestamp"].max()
             last_period_end = last_raw_ts + native_resolution_offset
             raw = pd.concat(

--- a/src/energy_cost/index/index.py
+++ b/src/energy_cost/index/index.py
@@ -50,7 +50,7 @@ class Index(RegistryMixin[str, "Index"], ABC):
 
         if self.forward_fill and raw.empty:
             # No data in the look-back window; find the most recent value before start_ts
-            fallback = self._get_values(pd.Timestamp.min.tz_localize(dt.UTC), fetch_start, timezone)
+            fallback = self._get_values(pd.Timestamp.min.tz_localize(timezone), fetch_start, timezone)
             if not fallback.empty:
                 raw = fallback.tail(1).copy()
 

--- a/src/energy_cost/index/index.py
+++ b/src/energy_cost/index/index.py
@@ -48,6 +48,12 @@ class Index(RegistryMixin[str, "Index"], ABC):
         fetch_start = start_ts - native_resolution_offset
         raw = self._get_values(fetch_start, end_ts, timezone)
 
+        if self.forward_fill and raw.empty:
+            # No data in the look-back window; find the most recent value before start_ts
+            fallback = self._get_values(pd.Timestamp.min.tz_localize(dt.UTC), fetch_start, timezone)
+            if not fallback.empty:
+                raw = fallback.tail(1).copy()
+
         if not raw.empty and not self.forward_fill:
             # explicitly add a timestamp one native resolution after the last raw timestamp with value `nan`
             # This way, they are not forward-filled with the last known value, but correctly marked as out-of-range.

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -55,6 +55,27 @@ def test_index_returns_nan_for_out_of_range_values() -> None:
     assert all(pd.isna(df["value"].tolist()[2:]))
 
 
+def test_index_forwards_fill_values_if_requested() -> None:
+    index = DataFrameIndex(
+        pd.DataFrame(
+            {"timestamp": pd.date_range("2020-01-01", periods=4, freq="15min"), "value": [1.0, 2.0, 3.0, 4.0]}
+        ),
+        resolution=dt.timedelta(minutes=15),
+        forward_fill=True,
+    )
+
+    Index.register("dummy", index)
+
+    df = index.get_values(
+        start=dt.datetime(2020, 1, 1, 0, 30),
+        end=dt.datetime(2020, 1, 1, 7, 0),
+        resolution=dt.timedelta(minutes=15),
+    )
+
+    assert df["value"].tolist()[:2] == [3.0, 4.0]
+    assert df["value"].tolist()[2:] == [4.0] * (len(df) - 2)
+
+
 def test_index_returns_all_nan_if_no_data_in_range() -> None:
     index = DataFrameIndex(
         pd.DataFrame(
@@ -74,7 +95,27 @@ def test_index_returns_all_nan_if_no_data_in_range() -> None:
     assert all(pd.isna(df["value"].tolist()))
 
 
-def test_index_ger_values_return_in_timezone_of_input() -> None:
+def test_index_still_returns_all_nan_values_if_forward_fill_requested_but_no_data_in_range() -> None:
+    index = DataFrameIndex(
+        pd.DataFrame(
+            {"timestamp": pd.date_range("2020-01-01", periods=4, freq="15min"), "value": [1.0, 2.0, 3.0, 4.0]}
+        ),
+        resolution=dt.timedelta(minutes=15),
+        forward_fill=True,
+    )
+
+    Index.register("dummy", index)
+
+    df = index.get_values(
+        start=dt.datetime(2021, 1, 1, 1, 0),
+        end=dt.datetime(2021, 1, 1, 2, 0),
+        resolution=dt.timedelta(minutes=15),
+    )
+
+    assert all(pd.isna(df["value"].tolist()))
+
+
+def test_index_get_values_return_in_timezone_of_input() -> None:
     index = DataFrameIndex(
         pd.DataFrame(
             {"timestamp": pd.date_range("2020-01-01", periods=4, freq="15min"), "value": [1.0, 2.0, 3.0, 4.0]}

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -95,7 +95,7 @@ def test_index_returns_all_nan_if_no_data_in_range() -> None:
     assert all(pd.isna(df["value"].tolist()))
 
 
-def test_index_still_returns_all_nan_values_if_forward_fill_requested_but_no_data_in_range() -> None:
+def test_index_still_forward_fills_if_no_data_in_range() -> None:
     index = DataFrameIndex(
         pd.DataFrame(
             {"timestamp": pd.date_range("2020-01-01", periods=4, freq="15min"), "value": [1.0, 2.0, 3.0, 4.0]}
@@ -112,7 +112,7 @@ def test_index_still_returns_all_nan_values_if_forward_fill_requested_but_no_dat
         resolution=dt.timedelta(minutes=15),
     )
 
-    assert all(pd.isna(df["value"].tolist()))
+    assert all(value == 4.0 for value in df["value"].tolist())
 
 
 def test_index_get_values_return_in_timezone_of_input() -> None:


### PR DESCRIPTION
This pull request adds an optional `forward_fill` param to Dataframe indexes. Upon creation of the Index you can specify if forward filling is allowed for this index. (Usefull for monthly indexes that are often only known after the fact)

I didn't at support for this in the Entsoe day ahead index, as it makes less sense there, and it could also become very slow. (If no data is available in the requested time range we request all index values from the beginning of time, to maybe get earlier index values from where we can forward fill).

Closes #80 