### PR TITLE
Implement get_values for min/max formulas

### DIFF
--- a/src/energy_cost/formula/minmax.py
+++ b/src/energy_cost/formula/minmax.py
@@ -84,6 +84,45 @@ def apply_extreme_formula(
     )
 
 
+def get_extreme_values(
+    formulas: list[Formula],
+    extreme_func: Callable[[pd.Series], float],
+    period: Resolution,
+    start: dt.datetime,
+    end: dt.datetime,
+    output_resolution: Resolution,
+    timezone: dt.tzinfo = dt.UTC,
+) -> pd.DataFrame:
+    if period != output_resolution:
+        raise NotImplementedError(
+            "Minimum/maximum get_values() only supports output_resolution equal to formula period. Use apply() instead."
+        )
+
+    value_frames = [
+        formula.get_values(
+            start=start,
+            end=end,
+            output_resolution=output_resolution,
+            timezone=timezone,
+        )
+        for formula in formulas
+    ]
+
+    merged = value_frames[0][["timestamp", "value"]].rename(columns={"value": "value_0"})
+    for i, frame in enumerate(value_frames[1:], start=1):
+        merged = merged.merge(
+            frame[["timestamp", "value"]].rename(columns={"value": f"value_{i}"}),
+            on="timestamp",
+            how="outer",
+        )
+
+    value_columns = [c for c in merged.columns if c.startswith("value_")]
+    merged["value"] = merged[value_columns].agg(extreme_func, axis=1)
+
+    result = merged[["timestamp", "value"]].sort_values("timestamp")
+    return result.reset_index(drop=True)
+
+
 class MinimumFormula(FormulaBase):
     """A formula returns the minimum formula result of multiple formulas in a given period."""
 
@@ -91,6 +130,23 @@ class MinimumFormula(FormulaBase):
     kind: Literal["minimum"] = "minimum"
     period: Resolution
     minimum: list[Formula] = Field(default_factory=list)
+
+    def get_values(
+        self,
+        start: dt.datetime,
+        end: dt.datetime,
+        output_resolution: Resolution,
+        timezone: dt.tzinfo = dt.UTC,
+    ) -> pd.DataFrame:
+        return get_extreme_values(
+            formulas=self.minimum,
+            extreme_func=min,
+            period=self.period,
+            start=start,
+            end=end,
+            output_resolution=output_resolution,
+            timezone=timezone,
+        )
 
     def apply(
         self,
@@ -121,6 +177,23 @@ class MaximumFormula(FormulaBase):
     kind: Literal["maximum"] = "maximum"
     period: Resolution
     maximum: list[Formula] = Field(default_factory=list)
+
+    def get_values(
+        self,
+        start: dt.datetime,
+        end: dt.datetime,
+        output_resolution: Resolution,
+        timezone: dt.tzinfo = dt.UTC,
+    ) -> pd.DataFrame:
+        return get_extreme_values(
+            formulas=self.maximum,
+            extreme_func=max,
+            period=self.period,
+            start=start,
+            end=end,
+            output_resolution=output_resolution,
+            timezone=timezone,
+        )
 
     def apply(
         self,

--- a/src/energy_cost/formula/minmax.py
+++ b/src/energy_cost/formula/minmax.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from abc import abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
@@ -30,188 +31,129 @@ def add_period_sum(df: pd.DataFrame, period_bins: pd.DatetimeIndex) -> pd.DataFr
     return df.merge(period_sums, on="period", how="left")
 
 
-def apply_extreme_formula(
-    formulas: list[Formula],
-    extreme_func: Callable[[pd.Series], float],
-    period: Resolution,
-    meter: Meter,
-    start: dt.datetime,
-    end: dt.datetime,
-    output_resolution: Resolution,
-    timezone: dt.tzinfo = dt.UTC,
-    binning_anchor: dt.datetime | None = None,
-) -> pd.DataFrame:
-    sub_resolution = find_common_divisor(output_resolution, period)
+class ExtremeFormulaBase(FormulaBase):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    period: Resolution
 
-    applied_dfs = [
-        formula.apply(
-            meter,
-            start=start,
-            end=end,
-            output_resolution=sub_resolution,
-            timezone=timezone,
-            binning_anchor=binning_anchor,
+    @property
+    @abstractmethod
+    def formulas(self) -> list[Formula]:
+        """Return child formulas to evaluate."""
+
+    @property
+    @abstractmethod
+    def extreme_func(self) -> Callable[[pd.Series], float]:
+        """Return the row-wise or period-wise selector function (min/max)."""
+
+    def get_values(
+        self,
+        start: dt.datetime,
+        end: dt.datetime,
+        output_resolution: Resolution,
+        timezone: dt.tzinfo = dt.UTC,
+    ) -> pd.DataFrame:
+        if self.period != output_resolution:
+            raise NotImplementedError(
+                "Minimum/maximum get_values() only supports output_resolution equal to formula period. "
+                "Use apply() instead."
+            )
+
+        value_frames = [
+            formula.get_values(
+                start=start,
+                end=end,
+                output_resolution=output_resolution,
+                timezone=timezone,
+            )
+            for formula in self.formulas
+        ]
+
+        merged = value_frames[0][["timestamp", "value"]].rename(columns={"value": "value_0"})
+        for i, frame in enumerate(value_frames[1:], start=1):
+            merged = merged.merge(
+                frame[["timestamp", "value"]].rename(columns={"value": f"value_{i}"}),
+                on="timestamp",
+                how="outer",
+            )
+
+        value_columns = [c for c in merged.columns if c.startswith("value_")]
+        merged["value"] = merged[value_columns].agg(self.extreme_func, axis=1)
+
+        result = merged[["timestamp", "value"]].sort_values("timestamp")
+        return result.reset_index(drop=True)
+
+    def apply(
+        self,
+        meter: Meter,
+        start: dt.datetime,
+        end: dt.datetime,
+        output_resolution: Resolution,
+        timezone: dt.tzinfo = dt.UTC,
+        binning_anchor: dt.datetime | None = None,
+    ) -> pd.DataFrame:
+        sub_resolution = find_common_divisor(output_resolution, self.period)
+
+        applied_dfs = [
+            formula.apply(
+                meter,
+                start=start,
+                end=end,
+                output_resolution=sub_resolution,
+                timezone=timezone,
+                binning_anchor=binning_anchor,
+            )
+            for formula in self.formulas
+        ]
+
+        freq = to_pandas_freq(self.period)
+        snapped_start, snapped_end = snap_billing_period(start, end, freq, anchor=binning_anchor)
+        period_bins = pd.date_range(start=snapped_start, end=snapped_end, freq=freq)
+
+        summed_by_period = [add_period_sum(df, period_bins) for df in applied_dfs]
+
+        # Add formula ID to resolve ties deterministically by declaration order.
+        for i, df in enumerate(summed_by_period):
+            df["formula_id"] = i
+
+        all_data = pd.concat(summed_by_period, ignore_index=True)
+        extreme_period_sums = (
+            all_data.groupby("period")["period_sum"].agg(self.extreme_func).reset_index(name="extreme_period_sum")
         )
-        for formula in formulas
-    ]
+        winners = all_data.merge(extreme_period_sums, on="period")
+        winners = winners[winners["period_sum"] == winners["extreme_period_sum"]]
+        winners = winners.sort_values(["timestamp", "formula_id"]).drop_duplicates(subset="timestamp", keep="first")
+        result = winners[["timestamp", "value"]].reset_index(drop=True)
 
-    freq = to_pandas_freq(period)
-    snapped_start, snapped_end = snap_billing_period(start, end, freq, anchor=binning_anchor)
-    period_bins = pd.date_range(start=snapped_start, end=snapped_end, freq=freq)
-
-    summed_by_period = [add_period_sum(df, period_bins) for df in applied_dfs]
-
-    # add formula ID to handle ties later (arbitrary choice to take the first one in case of ties, but we want it to be deterministic)
-    for i, df in enumerate(summed_by_period):
-        df["formula_id"] = i
-
-    # Now we have a list of DataFrames with 'timestamp', 'value', 'period', and 'period_sum' columns.
-    # We want to find the extreme 'period_sum' across the formulas for each period, and keep the corresponding timestamps and values from the winning formula.
-    # First, concatenate all the DataFrames and find the extreme period_sum for each period.
-    all_data = pd.concat(summed_by_period, ignore_index=True)
-    extreme_period_sums = (
-        all_data.groupby("period")["period_sum"].agg(extreme_func).reset_index(name="extreme_period_sum")
-    )
-    # Merge back to find the rows where period_sum equals extreme_period_sum
-    winners = all_data.merge(extreme_period_sums, on="period")
-    winners = winners[winners["period_sum"] == winners["extreme_period_sum"]]
-    # In case of ties, we take the first formula (lowest formula_id) for each period
-    winners = winners.sort_values(["timestamp", "formula_id"]).drop_duplicates(subset="timestamp", keep="first")
-    result = winners[["timestamp", "value"]].reset_index(drop=True)
-
-    return redistribute_to_resolution(
-        result, sub_resolution, output_resolution, start=start, end=end, binning_anchor=binning_anchor
-    )
-
-
-def get_extreme_values(
-    formulas: list[Formula],
-    extreme_func: Callable[[pd.Series], float],
-    period: Resolution,
-    start: dt.datetime,
-    end: dt.datetime,
-    output_resolution: Resolution,
-    timezone: dt.tzinfo = dt.UTC,
-) -> pd.DataFrame:
-    if period != output_resolution:
-        raise NotImplementedError(
-            "Minimum/maximum get_values() only supports output_resolution equal to formula period. Use apply() instead."
+        return redistribute_to_resolution(
+            result, sub_resolution, output_resolution, start=start, end=end, binning_anchor=binning_anchor
         )
 
-    value_frames = [
-        formula.get_values(
-            start=start,
-            end=end,
-            output_resolution=output_resolution,
-            timezone=timezone,
-        )
-        for formula in formulas
-    ]
 
-    merged = value_frames[0][["timestamp", "value"]].rename(columns={"value": "value_0"})
-    for i, frame in enumerate(value_frames[1:], start=1):
-        merged = merged.merge(
-            frame[["timestamp", "value"]].rename(columns={"value": f"value_{i}"}),
-            on="timestamp",
-            how="outer",
-        )
-
-    value_columns = [c for c in merged.columns if c.startswith("value_")]
-    merged["value"] = merged[value_columns].agg(extreme_func, axis=1)
-
-    result = merged[["timestamp", "value"]].sort_values("timestamp")
-    return result.reset_index(drop=True)
-
-
-class MinimumFormula(FormulaBase):
+class MinimumFormula(ExtremeFormulaBase):
     """A formula returns the minimum formula result of multiple formulas in a given period."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
     kind: Literal["minimum"] = "minimum"
-    period: Resolution
     minimum: list[Formula] = Field(default_factory=list)
 
-    def get_values(
-        self,
-        start: dt.datetime,
-        end: dt.datetime,
-        output_resolution: Resolution,
-        timezone: dt.tzinfo = dt.UTC,
-    ) -> pd.DataFrame:
-        return get_extreme_values(
-            formulas=self.minimum,
-            extreme_func=min,
-            period=self.period,
-            start=start,
-            end=end,
-            output_resolution=output_resolution,
-            timezone=timezone,
-        )
+    @property
+    def formulas(self) -> list[Formula]:
+        return self.minimum
 
-    def apply(
-        self,
-        meter: Meter,
-        start: dt.datetime,
-        end: dt.datetime,
-        output_resolution: Resolution,
-        timezone: dt.tzinfo = dt.UTC,
-        binning_anchor: dt.datetime | None = None,
-    ) -> pd.DataFrame:
-        return apply_extreme_formula(
-            formulas=self.minimum,
-            extreme_func=min,
-            period=self.period,
-            meter=meter,
-            start=start,
-            end=end,
-            output_resolution=output_resolution,
-            timezone=timezone,
-            binning_anchor=binning_anchor,
-        )
+    @property
+    def extreme_func(self) -> Callable[[pd.Series], float]:
+        return min
 
 
-class MaximumFormula(FormulaBase):
+class MaximumFormula(ExtremeFormulaBase):
     """A formula returns the maximum formula result of multiple formulas in a given period."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
     kind: Literal["maximum"] = "maximum"
-    period: Resolution
     maximum: list[Formula] = Field(default_factory=list)
 
-    def get_values(
-        self,
-        start: dt.datetime,
-        end: dt.datetime,
-        output_resolution: Resolution,
-        timezone: dt.tzinfo = dt.UTC,
-    ) -> pd.DataFrame:
-        return get_extreme_values(
-            formulas=self.maximum,
-            extreme_func=max,
-            period=self.period,
-            start=start,
-            end=end,
-            output_resolution=output_resolution,
-            timezone=timezone,
-        )
+    @property
+    def formulas(self) -> list[Formula]:
+        return self.maximum
 
-    def apply(
-        self,
-        meter: Meter,
-        start: dt.datetime,
-        end: dt.datetime,
-        output_resolution: Resolution,
-        timezone: dt.tzinfo = dt.UTC,
-        binning_anchor: dt.datetime | None = None,
-    ) -> pd.DataFrame:
-        return apply_extreme_formula(
-            formulas=self.maximum,
-            extreme_func=max,
-            period=self.period,
-            meter=meter,
-            start=start,
-            end=end,
-            output_resolution=output_resolution,
-            timezone=timezone,
-            binning_anchor=binning_anchor,
-        )
+    @property
+    def extreme_func(self) -> Callable[[pd.Series], float]:
+        return max

--- a/tests/formula/test_minimum.py
+++ b/tests/formula/test_minimum.py
@@ -10,7 +10,25 @@ from energy_cost.formula import IndexFormula, MaximumFormula, MinimumFormula, Pe
 from energy_cost.meter import Meter, TimeseriesFrame
 
 
-def test_minimum_formula_get_values_raises_not_implemented() -> None:
+def test_minimum_formula_get_values_takes_rowwise_minimum() -> None:
+    formula = MinimumFormula(
+        period=isodate.parse_duration("P1M"),
+        minimum=[
+            IndexFormula(constant_cost=1.0),
+            IndexFormula(constant_cost=3.0),
+        ],
+    )
+
+    out = formula.get_values(
+        start=dt.datetime(2025, 1, 1, 0, 0),
+        end=dt.datetime(2025, 2, 1, 0, 0),
+        output_resolution=isodate.parse_duration("P1M"),
+    )
+
+    assert out["value"].tolist() == pytest.approx([1.0])
+
+
+def test_minimum_formula_get_values_raises_when_period_differs_from_resolution() -> None:
     formula = MinimumFormula(
         period=isodate.parse_duration("P1M"),
         minimum=[IndexFormula(constant_cost=1.0)],
@@ -20,7 +38,7 @@ def test_minimum_formula_get_values_raises_not_implemented() -> None:
         formula.get_values(
             start=dt.datetime(2025, 1, 1, 0, 0),
             end=dt.datetime(2025, 2, 1, 0, 0),
-            output_resolution=isodate.parse_duration("P1M"),
+            output_resolution=isodate.parse_duration("P1D"),
         )
 
 
@@ -232,7 +250,25 @@ def test_minimum_formula_model_validate_from_dict() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_maximum_formula_get_values_raises_not_implemented() -> None:
+def test_maximum_formula_get_values_takes_rowwise_maximum() -> None:
+    formula = MaximumFormula(
+        period=isodate.parse_duration("P1M"),
+        maximum=[
+            IndexFormula(constant_cost=1.0),
+            IndexFormula(constant_cost=3.0),
+        ],
+    )
+
+    out = formula.get_values(
+        start=dt.datetime(2025, 1, 1, 0, 0),
+        end=dt.datetime(2025, 2, 1, 0, 0),
+        output_resolution=isodate.parse_duration("P1M"),
+    )
+
+    assert out["value"].tolist() == pytest.approx([3.0])
+
+
+def test_maximum_formula_get_values_raises_when_period_differs_from_resolution() -> None:
     formula = MaximumFormula(
         period=isodate.parse_duration("P1M"),
         maximum=[IndexFormula(constant_cost=1.0)],
@@ -242,7 +278,7 @@ def test_maximum_formula_get_values_raises_not_implemented() -> None:
         formula.get_values(
             start=dt.datetime(2025, 1, 1, 0, 0),
             end=dt.datetime(2025, 2, 1, 0, 0),
-            output_resolution=isodate.parse_duration("P1M"),
+            output_resolution=isodate.parse_duration("P1D"),
         )
 
 


### PR DESCRIPTION
This pull request implements get_values for minimum and maximum formulas.

It is only implemented in the case where the requested resolution equals the formula period.
This is because other cases are not well defined.

In essence `max(a*b, a*c)=a*max(b,c)`, but `max(a1*b1 + a2*b2, a1*c1 +a2*c2) != a1*max(b1, c1)+a2*max(b2, c2)`.
And the similar issue persists for other resolutions, so there is no valid response for `get_values`

I've also refactored the file a bit in this pr to use object inheritance instead of helper functions, which makes it more in line with the rest of the code base.

Closes #127 