### PR TITLE
Implement Belgian excise changes

### DIFF
--- a/src/energy_cost/data/be/electricity/fees/protected.yml
+++ b/src/energy_cost/data/be/electricity/fees/protected.yml
@@ -47,3 +47,11 @@
     energy_contribution:
         constant_cost: 1.9261
 - start: 2023-04-01T00:00:00+02:00
+- start: 2023-07-01T00:00:00+02:00
+  consumption:
+    excise:
+      constant_cost: 23.62
+- start: 2026-08-01T00:00:00+02:00
+  consumption:
+    excise:
+      constant_cost: 1

--- a/src/energy_cost/data/be/electricity/fees/residential.yml
+++ b/src/energy_cost/data/be/electricity/fees/residential.yml
@@ -94,3 +94,19 @@
             constant_cost: 36.28
     energy_contribution:
         constant_cost: 1.9261
+- start: 2026-08-01T00:00:00+02:00
+  consumption:
+    excise:
+      constant_cost: 46
+- start: 2027-01-01T00:00:00+01:00
+  consumption:
+    excise:
+      constant_cost: 43
+- start: 2028-01-01T00:00:00+01:00
+  consumption:
+    excise:
+      constant_cost: 40
+- start: 2029-01-01T00:00:00+01:00
+  consumption:
+    excise:
+      constant_cost: 38

--- a/src/energy_cost/data/be/gas/fees/protected.yml
+++ b/src/energy_cost/data/be/gas/fees/protected.yml
@@ -27,3 +27,19 @@
   consumption:
     excise:
       constant_cost: 2.77
+- start: "2026-08-01T00:00:00+02:00"
+  consumption:
+    excise:
+      constant_cost: 3.09
+- start: "2027-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      constant_cost: 3.42
+- start: "2028-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      constant_cost: 3.74
+- start: "2029-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      constant_cost: 4.08

--- a/src/energy_cost/data/be/gas/fees/residential.yml
+++ b/src/energy_cost/data/be/gas/fees/residential.yml
@@ -160,3 +160,67 @@
             constant_cost: 8.23
         - formula:
             constant_cost: 9.0782
+- start: "2026-04-01T00:00:00+02:00"
+  consumption:
+    energy_contribution:
+      constant_cost: 0.9978
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 8.23
+        - formula:
+            constant_cost: 9.3061
+- start: "2026-07-01T00:00:00+02:00"
+  consumption:
+    energy_contribution:
+      constant_cost: 0.9978
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 8.23
+        - formula:
+            constant_cost: 9.3315
+- start: "2026-08-01T00:00:00+02:00"
+  consumption:
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 10.31
+        - formula:
+            constant_cost: 11.16
+- start: "2027-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 11.39
+        - formula:
+            constant_cost: 12.24
+- start: "2028-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 11.39
+        - formula:
+            constant_cost: 12.24
+- start: "2029-01-01T00:00:00+01:00"
+  consumption:
+    excise:
+      band_period: P1Y
+      bands:
+        - up_to: 12
+          formula:
+            constant_cost: 13.60
+        - formula:
+            constant_cost: 14.45


### PR DESCRIPTION
This pull request implements the Belgian excise changes as decided in the law of may 30th.

Source: https://www.minfin.fgov.be/myminfin-web/pages/public/fisconet/document/b91925cd-fbba-4da5-8b9a-06974300ff1e#_Toc2592358

Extra positive is that the values are already known until 2029. So normally no quarterly updates will be required anymore.

Also contains a fix to the protected customer electricity excise, where we missed an entry from 2023-07-01.